### PR TITLE
fix flaky test testSerialize

### DIFF
--- a/authentication-models/src/test/java/com/alexkudlick/authentication/models/AuthenticationRequestTest.java
+++ b/authentication-models/src/test/java/com/alexkudlick/authentication/models/AuthenticationRequestTest.java
@@ -35,8 +35,7 @@ public class AuthenticationRequestTest {
                 "\"userName\":\"testUserName\"" +
                 "}";
         String serialized = new ObjectMapper().writeValueAsString(request);
-        Boolean assertionVal=expectedJson2.equals(serialized) || expectedJson1.equals(serialized);
-        assertTrue(assertionVal);
+        assertTrue(expectedJson2.equals(serialized) || expectedJson1.equals(serialized));
     }
 
 }

--- a/authentication-models/src/test/java/com/alexkudlick/authentication/models/AuthenticationRequestTest.java
+++ b/authentication-models/src/test/java/com/alexkudlick/authentication/models/AuthenticationRequestTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class AuthenticationRequestTest {
 
@@ -25,15 +26,17 @@ public class AuthenticationRequestTest {
     @Test
     public void testSerialize() throws IOException {
         AuthenticationRequest request = new AuthenticationRequest("testUserName", "testPassword");
-        String expectedJson = "{" +
-            "\"userName\":\"testUserName\"," +
-            "\"password\":\"testPassword\"" +
-        "}";
+        String expectedJson1 = "{" +
+                "\"userName\":\"testUserName\"," +
+                "\"password\":\"testPassword\"" +
+                "}";
+        String expectedJson2 = "{" +
+                "\"password\":\"testPassword\"," +
+                "\"userName\":\"testUserName\"" +
+                "}";
         String serialized = new ObjectMapper().writeValueAsString(request);
-        assertEquals(
-            expectedJson,
-            serialized
-        );
+        Boolean assertionVal=expectedJson2.equals(serialized) || expectedJson1.equals(serialized);
+        assertTrue(assertionVal);
     }
 
 }


### PR DESCRIPTION
## PR Overview

The PR proposes a fix for the following tests -
[com.alexkudlick.authentication.models.AuthenticationRequestTest.testSerialize](https://github.com/akud/modular-java-example/blob/a22b421df13ffae6fdcaec32316859131b605560/authentication-models/src/test/java/com/alexkudlick/authentication/models/AuthenticationRequestTest.java#L27)

## Test Overview
The `testSerialize()` function converts a JSON into the stringified version of itself and checks whether it is equal to its expected value. In order to run this test, I had used the following commands -
- To build the project :
```
./gradle build +x test
```
- To run the test :
```
./gradlew --info test --tests com.alexkudlick.authentication.models.AuthenticationRequestTest.testSerialize
```
- To run the nondex tool on this test :
```
./gradlew --info  --tests com.alexkudlick.authentication.models.AuthenticationRequestTest.testSerialize
```
## Problem 
This flakiness was identified by the [nondex tool](https://github.com/TestingResearchIllinois/NonDex) created by the researchers of UIUC
https://github.com/akud/modular-java-example/blob/438bc99147e45aa3a6c81f5211fdfdbc3641ea9f/authentication-models/src/test/java/com/alexkudlick/authentication/models/AuthenticationRequestTest.java#L26-L37
When `testSerialize()` tries to seriliaze/stringify the `AuthenticationRequest request` value. It uses `writeValueAsString()` to convert the JSON to string. This function is from the library Jackson ObjectMapper() and it does not maintain the order of insertion when it converts the JSON into string. 
This means for the folllowing input json 
```
{
            "userName":"testUserName",
            "password":"testPassword" 
}
```
The output can be either 
```
"{" +
                "\"userName\":\"testUserName\"," +
                "\"password\":\"testPassword\"" +
"}";
```

```
"{" +
                "\"userName\":\"testUserName\"," +
                "\"password\":\"testPassword\"" +
"}";
```
The possibility of having two outputs for one input allows the test to fail when running the nondex tool

## Fix:
The proposed fix simply compares with the second variation from the serialisation for the following reasons:
- The test has only two values in the JSON
- The test uses a library and changing that would create more code changes and also possibly affect the notion of having the test in the first place (which is to compare serialised json values)
https://github.com/anirudh711/modular-java-example/blob/a22b421df13ffae6fdcaec32316859131b605560/authentication-models/src/test/java/com/alexkudlick/authentication/models/AuthenticationRequestTest.java#L29-L39