### PR TITLE
fix flaky tests

### DIFF
--- a/authentication-models/src/main/java/com/alexkudlick/authentication/models/AuthenticationRequest.java
+++ b/authentication-models/src/main/java/com/alexkudlick/authentication/models/AuthenticationRequest.java
@@ -9,7 +9,7 @@ import org.hibernate.validator.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import java.util.Objects;
 
-@JsonPropertyOrder({userName, password})
+@JsonPropertyOrder({"userName", "password"})
 public class AuthenticationRequest {
 
     @JsonProperty("userName")

--- a/authentication-models/src/main/java/com/alexkudlick/authentication/models/AuthenticationRequest.java
+++ b/authentication-models/src/main/java/com/alexkudlick/authentication/models/AuthenticationRequest.java
@@ -1,6 +1,7 @@
 package com.alexkudlick.authentication.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.google.common.base.Preconditions;
 import org.hibernate.validator.constraints.Length;
 import org.hibernate.validator.constraints.NotEmpty;
@@ -8,6 +9,7 @@ import org.hibernate.validator.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import java.util.Objects;
 
+@JsonPropertyOrder({userName, password})
 public class AuthenticationRequest {
 
     @JsonProperty("userName")


### PR DESCRIPTION
## PR Overview

The PR proposes a fix for the following tests -
[com.alexkudlick.authentication.client.AuthenticationClientTest.testCreateUser](https://github.com/akud/modular-java-example/blob/438bc99147e45aa3a6c81f5211fdfdbc3641ea9f/authentication-client/src/test/java/com/alexkudlick/authentication/client/AuthenticationClientTest.java#L55)
[com.alexkudlick.authentication.client.AuthenticationClientTest.testCreateUserThrowsOn409s](https://github.com/akud/modular-java-example/blob/438bc99147e45aa3a6c81f5211fdfdbc3641ea9f/authentication-client/src/test/java/com/alexkudlick/authentication/client/AuthenticationClientTest.java#L68)
[com.alexkudlick.authentication.client.AuthenticationClientTest.testSuccessfulLogin](https://github.com/akud/modular-java-example/blob/438bc99147e45aa3a6c81f5211fdfdbc3641ea9f/authentication-client/src/test/java/com/alexkudlick/authentication/client/AuthenticationClientTest.java#L86)
[com.alexkudlick.authentication.client.AuthenticationClientTest.testUnsuccessfulLogin](https://github.com/akud/modular-java-example/blob/438bc99147e45aa3a6c81f5211fdfdbc3641ea9f/authentication-client/src/test/java/com/alexkudlick/authentication/client/AuthenticationClientTest.java#L100)

## Test Overview
These three tests test for user creation and login and they use the same underlying construct of creating an `AuthenticationRequest` with a body-
- To build the project :
```
./gradlew build 
```
- To run the test :
```
./gradlew --info test --tests com.alexkudlick.authentication.client.AuthenticationClientTest.testCreateUser
```
- To run the nondex tool on this test :
```
./gradlew --info  --tests=com.alexkudlick.authentication.client.AuthenticationClientTest.testCreateUser
```
## Problem 
This flakiness was identified by the [nondex tool](https://github.com/TestingResearchIllinois/NonDex) created by the researchers of UIUC
https://github.com/akud/modular-java-example/blob/438bc99147e45aa3a6c81f5211fdfdbc3641ea9f/authentication-client/src/test/java/com/alexkudlick/authentication/client/AuthenticationClientTest.java#L93-L96
When a new `AuthenticationRequest` object is created with arguments for username and password and is asserted using `argThat`. This assertion checks for the order of the attributes in the JSON string. However, the order is not maintained 
This means for the folllowing input json 
```
{ "userName":"testUserName", "password":"testPassword" }
```
The serialized output can be either 
```
{ "userName":"testUserName", "password":"testPassword" }

```

```
{ "password":"testPassword", "userName":"testUserName" }
```
The possibility of having two outputs for one input allows the test to fail when running the nondex tool

## Fix:
The proposed fix simply ensures the order to be set before it is being compared to the expected order using `@JsonPropertyOrder`

https://github.com/anirudh711/modular-java-example/blob/66582076cc68fc27955f0dc21d8e1dc8840ae142/authentication-models/src/main/java/com/alexkudlick/authentication/models/AuthenticationRequest.java#L12-L5